### PR TITLE
Fix library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
   {
     		"type": "git",
     		"url": "https://github.com/JHershey69/OpenWeatherOneCall.git"
-  }
+  },
   "authors": 
   [
 	{

--- a/library.json
+++ b/library.json
@@ -11,12 +11,10 @@
 	}
   ], 
   "repository": 
-  [
-	{
+  {
     		"type": "git",
-    		"url": "https://github.com/jhershey69/OpenWeatherOnecall.git"
-   	}
-  ],
+    		"url": "https://github.com/JHershey69/OpenWeatherOneCall.git"
+  }
   "authors": 
   [
 	{
@@ -33,6 +31,5 @@
 		]
 	},
   "frameworks": "arduino",
-  "board": "esp32dev",
   "platforms": "espressif32"
 }

--- a/library.json
+++ b/library.json
@@ -6,8 +6,9 @@
   "dependencies": 
   [
 	{
-	"name": "ArduinoJson",
-	"version": "^6.17.2"
+		"owner": "bblanchon",
+		"name": "ArduinoJson",
+		"version": "^6.17.2"
 	}
   ], 
   "repository": 


### PR DESCRIPTION
Corrects multiple errors in the `library.json` that makes it impossible to install in PlatformIO:
* removed unknown `board` key (per [docs](https://docs.platformio.org/en/latest/librarymanager/config.html))
* fixed `repository` to be an object, not an array
* added owner name to ArduinoJson dependency to avoid "More than one package has been found by name.." warning
* Fix upper/lower-casing in github URL just for consistency

Gets library installation from

```
>pio lib -g install https://github.com/JHershey69/OpenWeatherOneCall/archive/refs/heads/master.zip
Library Storage: C:\Users\Max\.platformio\lib
Library Manager: Installing https://github.com/JHershey69/OpenWeatherOneCall/archive/refs/heads/master.zip
Downloading...
Error: Traceback (most recent call last):
[...]
  File "c:\users\max\appdata\local\programs\python\python38\lib\site-packages\platformio\package\manifest\parser.py", line 155, in __init__
    self._data = self.normalize_repository(self._data)
  File "c:\users\max\appdata\local\programs\python\python38\lib\site-packages\platformio\package\manifest\parser.py", line 213, in normalize_repository
    url = (data.get("repository") or {}).get("url")
AttributeError: 'list' object has no attribute 'get'

============================================================
```

to

```
x>pio lib -g install https://github.com/maxgerhardt/OpenWeatherOneCall/archive/refs/heads/master.zip
Library Storage: C:\Users\Max\.platformio\lib
Library Manager: Installing https://github.com/maxgerhardt/OpenWeatherOneCall/archive/refs/heads/master.zip
Downloading...
Library Manager: OpenWeatherOneCall @ 3.1.0 has been installed!
Library Manager: Installing dependencies...
Library Manager: Installing bblanchon/ArduinoJson @ ^6.17.2
Library Manager: ArduinoJson @ 6.18.3 has been installed!
```